### PR TITLE
Added documentation and additional examples - commit signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 # GitHub action to generate a CycloneDX SBOM for Node.js
 
+This GitHub action will create a a valid CycloneDX Software Bill-of-Materials (SBOM) containing an aggregate of all project dependencies. CycloneDX is a lightweight SBOM specification that is easily created, human and machine readable, and simple to parse.
+
+This GitHub action requires a node_modules directory so this action will typically need to run after an npm build.
+
 ## Inputs
 
 ### `path`
@@ -31,6 +35,28 @@ uses: CycloneDX/gh-node-module-generatebom@master
 - name: Create SBOM step
   uses: CycloneDX/gh-node-module-generatebom@master
   with:
-    output: 'test.bom.xml'
-    path: './bom_directory/'
+    path: './node_project/'
+    output: './bom_directory/test.app.bom.xml'
+```
+
+## Complete Action with npm build and SBOM creation
+
+```
+name: Build javascript project
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Install and build javascript
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+      - run: npm install
+      - name: Create SBOM
+        uses: CycloneDX/gh-node-module-generatebom@master
+        with: 
+          output: './test.app.bom.xml'
 ```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,18 @@ Output filename, default is "./bom.xml"
 
 Be sure to quote paths with spaces.
 
-## Example usage
+## Example simple usage
 
 ```
 uses: CycloneDX/gh-node-module-generatebom@master
+```
+
+## Example step that defines the output and path (both are optional)
+
+```
+- name: Create SBOM step
+  uses: CycloneDX/gh-node-module-generatebom@master
+  with:
+    output: 'test.bom.xml'
+    path: './bom_directory/'
 ```

--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ jobs:
         with: 
           output: './test.app.bom.xml'
 ```
-

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
         with:
           node-version: '14'
       - run: npm install
-      - name: Create SBOM
+      - name: Create SBOM with CycloneDX
         uses: CycloneDX/gh-node-module-generatebom@master
         with: 
           output: './test.app.bom.xml'

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ jobs:
         with: 
           output: './test.app.bom.xml'
 ```
+


### PR DESCRIPTION
I wanted to flesh out the documentation for this GitHub Action a bit so that it was easier for users to add the CycloneDX action to their repositories.  I added a bit of an explanation and then two additional examples:  one for using the path and output parameters and one that attempts to be a complete action file with npm build and SBOM creation.