### PR TITLE
pin dependnecy `@cyclonedx/bom`

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ try {
     execSync('cyclonedx-bom --help');
   } catch (error) {
     console.log('Installing CycloneDX...');
-    let output = execSync('npm install -g @cyclonedx/bom', { encoding: 'utf-8' });
+    let output = execSync("npm install -g '@cyclonedx/bom@<4'", { encoding: 'utf-8' });
     console.log(output);
   }
 


### PR DESCRIPTION
prevent to install unexpected versions of `@cyclonedx/bom`


also in preparation for https://github.com/CycloneDX/cyclonedx-node-module/pull/321 

a rework of this GH-action to support newer versions or even other processes may happen later.