### PR TITLE
Bump node version to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     default: ./bom.xml
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
As per https://github.com/CycloneDX/gh-node-module-generatebom/issues/1 and https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ node 12 is deprecated.

As far as I can tell, javascript actions do not yet support node versions >16. There is an open discussion here: https://github.com/orgs/community/discussions/53217

If anyone knows otherwise, I would be happy to update to a later version. In the meantime, this should fix the deprecation warnings shown when running this action.

Also, I am not that familiar with developing github actions, if I have missed something please let me know. I tested this change in our build and it worked as expected.