### PR TITLE
fix: correct typo in NPM SBOM package name (@cyclonedx/cyclonedx-npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > This GitHub Action is considered deprecated.  
 > Instead, you may use one of the following tools in your github workflow:
 >
-> - for NPM projects: [`@yclonedx/cyclonedx-npm`](https://www.npmjs.com/package/%40cyclonedx/cyclonedx-npm)
+> - for NPM projects: [`@cyclonedx/cyclonedx-npm`](https://www.npmjs.com/package/%40cyclonedx/cyclonedx-npm)
 >   ```yaml
 >   - name: Create SBOM step
 >     # see for usage: https://www.npmjs.com/package/%40cyclonedx/cyclonedx-npm


### PR DESCRIPTION
This PR corrects a typographical error in the documentation for generating a Software Bill of Materials (SBOM) for NPM projects.

#### Issue

The package was incorrectly referenced as:

```
@yclonedx/cyclonedx-npm
```

This would result in a command failure for users following the guide.

#### Correction

Updated to the correct scoped package name:

```
@cyclonedx/cyclonedx-npm
```

#### Reference

* [[npmjs.com/package/@cyclonedx/cyclonedx-npm](https://www.npmjs.com/package/@cyclonedx/cyclonedx-npm)](https://www.npmjs.com/package/@cyclonedx/cyclonedx-npm)

This fix ensures the documentation accurately reflects the official CycloneDX NPM tool.
